### PR TITLE
Add additional proteome options

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,13 @@
 
 ## Processing steps
 
-1. Download Rhea DB (of metabolites) in preparation for searching.
+**scbirlab/nf-ggi** carries out the following steps:
+
+1. [Optional] Download Rhea DB (of metabolites) in preparation for searching.
 
 For proteins or proteomes in the [sample sheet](#sample-sheet):
 
-1. Download its STRING database and tidy up the data.
+1. [Optional] Download its STRING database and tidy up the data.
 2. Download FASTA sequences of proteins from UniProt
     - If multiple proteomes are available, choose according to this priority: "Reference and representative", "Reference", "Representative", "Other"
 3. Find reactions in Rhea DB and connect products with reactants between enzymes in the proteome.
@@ -47,15 +49,15 @@ For `method == "custom"`:
 
 5. All unique pairs of proteins listed.
 
-Then for each protein pair, optionally:
+Then for each protein pair, **optionally**:
 
-6. Calculate the co-evolutionary signal with DCA, optionally generating plots of contact maps.
-7. Predict the interface contact map with `yunta rf2t` (RosettaFold-2track), optionally generating plots of contact maps.
-8. Predict the protein-protein complex structure map with `yunta af2` (AlphaFold2), optionally generating plots of contact maps.
+6. with `--dca`: Calculate the co-evolutionary signal with DCA, optionally generating plots of contact maps.
+7. with `--rf2t`: Predict the interface contact map with `yunta rf2t` (RosettaFold-2track), optionally generating plots of contact maps.
+8. with `--af2`: Predict the protein-protein complex structure map with `yunta af2` (AlphaFold2), optionally generating plots of contact maps.
 
 ## Requirements
 
-You need access to the UniClust and BFD databases, and you need Nextflow and conda to be installed.
+You need access to the UniClust and BFD databases, and you need Nextflow and either conda, Singularity, or Docker to be installed.
 
 ### Databases
 
@@ -107,9 +109,9 @@ source ~/.bash_profile
 
 There are three run modes for the pipeline:
 
-- "self": run all protein-protein interactions within an organism
-- "bait": run interactions between all proteins from an organism and either one protein or another organism's proteome
-- "custom": run specified protein pairs from a file
+- `"self"`: run all protein-protein interactions within an organism
+- `"bait"`: run interactions between all proteins from an organism and either one protein or another organism's proteome
+- `"custom"`: run specified protein pairs from a file
 
 The easiest way to get going is by specifying parameters on the command-line:
 
@@ -125,11 +127,12 @@ nextflow run scbirlab/nf-ggi \
 Here's what the flags mean:
 - `--organism_id`: The Taxon ID of the organism, whih you can find at NCBI or UniProt
 - `--dca`, `--rf2t`: Run direct-coupling analysis and RosettaFold-2track
-- `--plots`: Generate amino acid contact maps. This takes about 10MB per protein-protein interaction, so be sure you have enough disk space!
+- `--plots`: Generate amino acid contact maps. This takes about 10MB per protein-protein interaction, 
+so be sure you have enough disk space for the number of protein-protein pairs you're testing!
 
-You could also run `--metabolites` to get the metabolic network, and `--string` to get the STRING co-expression network.
+You can also run `--metabolites` to get the metabolic network, and `--string` to get the STRING co-expression network.
 
-Because only `--organism_id` is provided, the pipeline assumes "self" mode (i.e. all-vs-all within taxon 243273).
+Because only `--organism_id` was provided, the pipeline assumes "self" mode (i.e. all-vs-all within taxon 243273).
 
 You can run bait mode by providing `--bait <UniProt ID>`:
 
@@ -147,6 +150,11 @@ nextflow run scbirlab/nf-ggi --bfd "$bfd" --uniclust "$uniclust" \
     --bait_is_taxon --interspecies \
     --rf2t
 ```
+
+### Running with Singularity, Docker, or Conda
+
+**scbirlab/nf-ggi** runs on a Singularity container engine by default to ensure software versions are consistent. If you have 
+docker installed, you can run using `-with-docker` to use it instead, or if you have Conda you can run `-with-conda`.
 
 ### Running more than one query in parallel
 
@@ -167,10 +175,10 @@ pipeline, use the `-latest` flag.
 nextflow run scbirlab/nf-ggi -latest
 ```
 
-If you want to run a particular tagged version of the pipeline, such as `v0.0.2`, you can do so using
+If you want to run a particular tagged version of the pipeline, such as `v0.0.3`, you can do so using
 
 ```bash 
-nextflow run scbirlab/nf-ggi -r v0.0.2
+nextflow run scbirlab/nf-ggi -r v0.0.3
 ```
 
 For help, use `nextflow run scbirlab/nf-ggi --help`.

--- a/README.md
+++ b/README.md
@@ -134,13 +134,18 @@ Because only `--organism_id` is provided, the pipeline assumes "self" mode (i.e.
 You can run bait mode by providing `--bait <UniProt ID>`:
 
 ```bash
-nextflow run scbirlab/nf-ggi --bfd "$bfd" --uniclust "$uniclust" --organism_id 559292 --bait P00931 --dca
+nextflow run scbirlab/nf-ggi --bfd "$bfd" --uniclust "$uniclust" \
+    --organism_id 559292 --bait P00931 \
+    --dca
 ```
 
 The bait can be another organisms's proteome. In this case, we need to specifiy that `--bait_is_taxon` and `--interspecies`:
 
 ```bash
-nextflow run scbirlab/nf-ggi --bfd "$bfd" --uniclust "$uniclust" --organism_id 559292 --bait 1773 --bait_is_taxon --interspecies --rf2t
+nextflow run scbirlab/nf-ggi --bfd "$bfd" --uniclust "$uniclust" \
+    --organism_id 559292 --bait 1773 \
+    --bait_is_taxon --interspecies \
+    --rf2t
 ```
 
 ### Running more than one query in parallel
@@ -181,13 +186,20 @@ The pipeline can be run with command-line arguments:
 
 ```bash
 # intra-species all-vs-all:
-nextflow run scbirlab/nf-ggi --uniclust <path> --bfd <path> --organism_id <taxon ID>
+nextflow run scbirlab/nf-ggi --uniclust <path> --bfd <path> \
+    --organism_id <taxon ID>
 # intra-species all-vs-1:
-nextflow run scbirlab/nf-ggi --uniclust <path> --bfd <path> --organism_id <taxon ID> --bait <UniProtID>
+nextflow run scbirlab/nf-ggi --uniclust <path> --bfd <path> \
+    --organism_id <taxon ID> --bait <UniProtID>
 # inter-species all-vs-all:
-nextflow run scbirlab/nf-ggi --uniclust <path> --bfd <path> --organism_id <taxon ID> --bait <taxon ID> --bait_is_taxon --interspecies
+nextflow run scbirlab/nf-ggi --uniclust <path> --bfd <path> \
+    --organism_id <taxon ID> --bait <taxon ID> \
+    --bait_is_taxon --interspecies
 # custom list of pairs:
-nextflow run scbirlab/nf-ggi --uniclust <path> --bfd <path> --organism_id <taxon ID> --filename <path> --column1 <gene-col1> --column2 <gene-col2> [--interspecies --organism_id2 <taxon ID>] [--format <gene-name-type>]
+nextflow run scbirlab/nf-ggi --uniclust <path> --bfd <path> \
+    --organism_id <taxon ID> \
+    --filename <path> --column1 <gene-col1> --column2 <gene-col2> \
+    [--interspecies --organism_id2 <taxon ID>] [--format <gene-name-type>]
 ```
 
 The following parameters are **required**:
@@ -205,6 +217,10 @@ The following parameters are **optional**. They have default values which can
  be overridden if necessary.
 
  ```bash
+ --reviewed      Only pull SwissProt reviewed proteins from proteome
+--isoforms       Additionally pull isoform sequences from proteome
+--proteome_opts  Additonal filters for pulling from proteome. Check 
+            https://www.ebi.ac.uk/proteins/api/doc/#!/proteins/search for options.
 --bait_is_taxon  Indicate that bait is an organism ID
 --interspecies   Run analysis between interacting species proteomes
 --plots          Generate contact map plots
@@ -237,16 +253,16 @@ The `proteome_name` column is not neccesary, but you can add extra columns with 
 
 If running with `mode = "bait"`, to do a pulldown against a single bait protein, add another column with the bait UniProt ID.
 
-| organism_id | proteome_name           | bait   | bait_name |
-| ----------- | ----------------------- | ------ | --------- |
-| 243273      | "Mycoplasma genitalium" | P47259 | FolD      |
+| organism_id | proteome_name         | bait   | bait_name |
+| ----------- | --------------------- | ------ | --------- |
+| 243273      | Mycoplasma genitalium | P47259 | FolD      |
 
 
 If running with `mode = "custom"`, to do a pulldown against a single bait protein, add another column with the bait UniProt ID.
 
-| organism_id | proteome_name              | format    | filename  | column1 | column2 |
-| ----------- | -------------------------- | --------- | --------- | -------- | -------- |
-| 559292      | "Saccharomyces cerevisiae" | Gene_Name | combos.csv | query_orf | array_orf |
+| organism_id | proteome_name            | format    | filename  | column1    | column2   |
+| ----------- | ------------------------ | --------- | --------- | ---------- | --------- |
+| 559292      | Saccharomyces cerevisiae | Gene_Name | combos.csv | query_orf | array_orf |
 
 In this case, `combos.csv` must be in the `inputs` folder defined above. It would look like:
 

--- a/main.nf
+++ b/main.nf
@@ -150,8 +150,8 @@ include {
    fetch_string_database;
 } from './modules/string.nf'
 include { 
-   fetch_fastas_from_organism_id;
-   fetch_fastas_from_organism_id as fetch_fastas_from_organism_id_bait;
+   fetch_fastas_from_organism_id2;
+   fetch_fastas_from_organism_id2 as fetch_fastas_from_organism_id_bait;
    fetch_fasta_from_uniprot_id;
    fetch_fastas_from_uniprot_ids;
    map_uniprot_ids_from_file;
@@ -217,11 +217,15 @@ workflow {
 
    if ( mode == 'self' || mode == 'bait' ) {
 
-      sample_rows
-         .map { tuple( it.organism_id, it.organism_id ) }
-         .unique()
-         | fetch_fastas_from_organism_id  // Organism ID, FASTAs gz
-      fetch_fastas_from_organism_id.out
+      fetch_fastas_from_organism_id2(
+         sample_rows
+            .map { tuple( it.organism_id, it.organism_id ) }
+            .unique(),
+         Channel.value(params.isoforms),
+         Channel.value(params.reviewed),
+         Channel.value(params.proteome_opts),
+      )  // Organism ID, FASTAs gz
+      fetch_fastas_from_organism_id2.out
          .splitFasta( elem: 1, record: [id: true, text: true] )  // Organism ID, FASTA text
          .map { [ it[0] ] + it[1].id.split('\\|')[1..2] + [ it[1].text ] }  // Organism ID, UniProtID, Entry Name, FASTA text
          .set { fastas_A0 }
@@ -244,8 +248,13 @@ workflow {
 
          if ( params.bait_is_taxon ) {
 
-            baits
-               | fetch_fastas_from_organism_id_bait  // Organism ID, bait FASTAs gz
+            fetch_fastas_from_organism_id_bait(
+               baits,
+               Channel.value(params.isoforms),
+               Channel.value(params.reviewed),
+               Channel.value(params.proteome_opts),
+            )  // Organism ID, bait FASTAs gz
+
             fetch_fastas_from_organism_id_bait.out
                .set { bait_fastas }
 

--- a/main.nf
+++ b/main.nf
@@ -43,6 +43,9 @@ if ( params.help ) {
                --column1, --column2   Column names from --filename to get protein IDs
 
          Command-line optional parameters:
+            --reviewed       Only pull SwissProt reviewed proteins from proteome
+            --isoforms       Additionally pull isoform sequences from proteome
+            --proteome_opts  Additonal filters for pulling from proteome. Check https://www.ebi.ac.uk/proteins/api/doc/#!/proteins/search for options.
             --bait_is_taxon  Indicate that bait is an organism ID
             --interspecies   Run analysis between interacting species proteomes
             --organism_id2   When providing a file of pairs, if the second protein (--column2) is from another organism than the first

--- a/main.nf
+++ b/main.nf
@@ -177,11 +177,11 @@ include {
 workflow {
 
    Channel.value( tuple(
-      file( params.bfd ).getBaseName(),
+      file( params.bfd ).getName(),
       file( "${params.bfd}_*", checkIfExists: true ),
    ) ).set { bfd }
    Channel.value( tuple(
-      file( params.uniclust ).getBaseName(),
+      file( params.uniclust ).getName(),
       file( "${params.uniclust}{_,.}*", checkIfExists: true ),
    ) ).set { uniclust }
    Channel.of( params.rhea_url ).set { rhea_url }

--- a/main.nf
+++ b/main.nf
@@ -157,8 +157,8 @@ include {
    fetch_string_database;
 } from './modules/string.nf'
 include { 
-   fetch_fastas_from_organism_id2;
-   fetch_fastas_from_organism_id2 as fetch_fastas_from_organism_id_bait;
+   fetch_fastas_from_organism_id_v3 as fetch_fastas_from_organism_id;
+   fetch_fastas_from_organism_id_v3 as fetch_fastas_from_organism_id_bait;
    fetch_fasta_from_uniprot_id;
    fetch_fastas_from_uniprot_ids;
    map_uniprot_ids_from_file;
@@ -230,7 +230,7 @@ workflow {
 
    if ( mode == 'self' || mode == 'bait' ) {
 
-      fetch_fastas_from_organism_id2(
+      fetch_fastas_from_organism_id(
          sample_rows
             .map { tuple( it.organism_id, it.organism_id ) }
             .unique(),
@@ -238,7 +238,7 @@ workflow {
          Channel.value(params.reviewed),
          Channel.value(params.proteome_opts),
       )  // Organism ID, FASTAs gz
-      fetch_fastas_from_organism_id2.out
+      fetch_fastas_from_organism_id.out
          .splitFasta( elem: 1, record: [id: true, text: true] )  // Organism ID, FASTA text
          .map { [ it[0] ] + it[1].id.split('\\|')[1..2] + [ it[1].text ] }  // Organism ID, UniProtID, Entry Name, FASTA text
          .set { fastas_A0 }

--- a/main.nf
+++ b/main.nf
@@ -112,6 +112,10 @@ log.info pipeline_title + """\
    mode                    : ${params.mode}
       Bait is Taxon ID     : ${params.bait_is_taxon}
       Interspecies         : ${params.interspecies}
+   proteome options
+      Reviewed             : ${params.reviewed}
+      Isoforms             : ${params.isoforms}
+      Other options        : ${params.proteome_opts}
    inputs
       input_dir            : ${params.inputs}
       sample sheet         : ${params.sample_sheet}

--- a/main.nf
+++ b/main.nf
@@ -176,8 +176,14 @@ include {
 
 workflow {
 
-   Channel.value( params.bfd ).set { bfd }
-   Channel.value( params.uniclust ).set { uniclust }
+   Channel.value( tuple(
+      file( params.bfd ).getBaseName(),
+      file( "${params.bfd}_*", checkIfExists: true ),
+   ) ).set { bfd }
+   Channel.value( tuple(
+      file( params.uniclust ).getBaseName(),
+      file( "${params.uniclust}{_,.}*", checkIfExists: true ),
+   ) ).set { uniclust }
    Channel.of( params.rhea_url ).set { rhea_url }
 
    if ( params.sample_sheet ) {

--- a/modules/msa.nf
+++ b/modules/msa.nf
@@ -3,8 +3,8 @@ process make_msa_from_fasta {
    tag "${id}"
    label 'big_cpu_mem'
    
-   errorStrategy 'retry'
-   maxRetries 2
+   // errorStrategy 'retry'
+   // maxRetries 2
 
    publishDir( 
       "${params.outputs}/msa", 
@@ -15,8 +15,8 @@ process make_msa_from_fasta {
    // Proteome ID, UniProtID, FASTA file, uniclust, bfd
    input:
    tuple val( id ), file( fasta )
-   val uniclust 
-   val bfd 
+   tuple val( uniclust_root ), path( uniclust ) 
+   tuple val( bfd_root ), path( bfd )
 
    output:
    tuple val( id ), file ( 'msa.a3m' )
@@ -25,7 +25,7 @@ process make_msa_from_fasta {
    script:
    """
    set -x
-   dbs=(${uniclust} ${bfd})
+   dbs=(${uniclust_root} ${bfd_root})
    for d in \${dbs[@]}
    do
    hhblits \

--- a/modules/uniprot.nf
+++ b/modules/uniprot.nf
@@ -113,6 +113,7 @@ process fetch_fastas_from_organism_id_v3 {
          .results[]
          | select(.proteomeType == "'"\$1"' proteome")
          | .id
+         | (first // empty)
       '
    )
    QUERIES=("Reference and representative" "Reference" "Representative" "Other")

--- a/modules/uniprot.nf
+++ b/modules/uniprot.nf
@@ -43,7 +43,7 @@ process fetch_fastas_from_organism_id {
 }
 
 
-process fetch_fastas_from_organism_id2 {
+process fetch_fastas_from_organism_id_v2 {
 
    tag "${id}"
 
@@ -65,7 +65,7 @@ process fetch_fastas_from_organism_id2 {
    script:
    def extra_params = extras ? "&${extras}" : ""
    def isoform_param = isoforms ? "&isoform=2" : "&isoform=0"
-   def reviewed_param = reviewed ? "&reviewed=true" : "&reviewed=false"
+   def reviewed_param = reviewed ? "&reviewed=true" : ""
    """
    set -x
    EBI_API_URL='https://www.ebi.ac.uk/proteins/api/proteins?'
@@ -100,7 +100,7 @@ process fetch_fastas_from_organism_id_v3 {
    script:
    def extra_params = extras ? "&${extras}" : ""
    def isoform_param = isoforms ? "&isoform=2" : "&isoform=0"
-   def reviewed_param = reviewed ? "&reviewed=true" : "&reviewed=false"
+   def reviewed_param = reviewed ? "&reviewed=true" : ""
    """
    set -x
    EBI_API_URL='https://www.ebi.ac.uk/proteins/api'
@@ -108,7 +108,7 @@ process fetch_fastas_from_organism_id_v3 {
    PROTEIN_PARAMS='${reviewed_param}${isoform_param}${extra_params}'
 
    curl -X GET --header 'Accept:application/json' \
-      "\$EBI_API_URL"'/proteomes?'"\$COMMON_PARAMS"'&taxid='"${organism_id}" \
+      "\$EBI_API_URL"'/proteomes?'"\$COMMON_PARAMS"'&is_redundant=false&taxid='"${organism_id}" \
       | jq -r '
          [ .[] | select(.redundantTo == null) ] as \$nr 
          
@@ -139,12 +139,14 @@ process fetch_fastas_from_organism_id_v3 {
    then
       echo "Could not find any gene-centric UniProt accessions for taxon ${organism_id}, proteome ID \$(head -n1 proteome-id.txt)!"
       echo " - Try ""\$EBI_API_URL"'/genecentric?'"\$COMMON_PARAMS"'&upid='"\$(head -n1 proteome-id.txt)"
-      exit 1
+      echo "Falling back to UniProt API"
+
+      curl 'https://rest.uniprot.org/uniprotkb/stream?query=(proteome:'"\$(head -n1 proteome-id.txt)"')&format=list&download=true' \
+      > uniprot-ids.txt
    fi
 
    split -l 100 uniprot-ids.txt 'chunk_'
    chunks=(chunk_*)
-
    for chunk in \${chunks[@]}
    do
       ids=\$(tr '\\n' ',' < "\$chunk")

--- a/modules/uniprot.nf
+++ b/modules/uniprot.nf
@@ -43,6 +43,67 @@ process fetch_fastas_from_organism_id {
 }
 
 
+process fetch_fastas_from_organism_id2 {
+
+   tag "${id}"
+
+   publishDir( 
+      "${params.outputs}/sequences", 
+      mode: 'copy',
+      saveAs: { "${id}-${organism_id}.fasta.gz" }
+   )
+
+   input:
+   tuple val( id ), val( organism_id )
+   val isoforms
+   val reviewed
+   val extras
+
+   output:
+   tuple val( id ), path( "proteome.fasta.gz" )
+
+   script:
+   def extra_params = extras ? "&${extras}" : ""
+   def isoform_param = isoforms ? "&isoform=2" : "&isoform=0"
+   def reviewed_param = reviewed ? "&reviewed=true" : "&reviewed=false"
+   """
+   set -x
+   EBI_API_URL='https://www.ebi.ac.uk/proteins/api/proteins?'
+   COMMON_PARAMS='offset=0&size=-1'
+   curl -X GET --header 'Accept:text/x-fasta' \
+      "\$EBI_API_URL""\$COMMON_PARAMS"'&taxid=${organism_id}${reviewed_param}${isoform_param}${extra_params}' \
+   | gzip --best \
+   > proteome.fasta.gz
+   """
+
+   """
+   function get_proteome_id() {
+      curl -s "https://rest.uniprot.org/proteomes/search?query=(taxonomy_id:${organism_id})&format=json" \
+      | jq '.results[] \
+      | select(.proteomeType == "'"\$1"' proteome").id'
+   }
+   QUERIES=("Reference and representative" "Reference" "Representative" "Other")
+   PROTEOME_ID=
+   for q in "\${QUERIES[@]}"
+   do
+      PROTEOME_ID=\$(get_proteome_id "\$q")
+      if [ ! -z \$PROTEOME_ID ]
+      then 
+         break
+      fi
+   done
+
+   wget "https://rest.uniprot.org/uniprotkb/stream?query=(proteome:\$PROTEOME_ID)&format=fasta&download=true&compressed=true" \
+      -O proteome.fasta.gz \
+      || (
+         echo "Failed to download taxonomy ID ${organism_id} with proteome ID \$PROTEOME_ID from UniProt"
+         exit 1   
+      )
+   """
+
+}
+
+
 process fetch_fasta_from_uniprot_id {
 
    tag "${uniprot_id}"

--- a/modules/uniprot.nf
+++ b/modules/uniprot.nf
@@ -78,6 +78,88 @@ process fetch_fastas_from_organism_id2 {
 }
 
 
+process fetch_fastas_from_organism_id_v3 {
+
+   tag "${id}"
+
+   publishDir( 
+      "${params.outputs}/sequences", 
+      mode: 'copy',
+      saveAs: { "${id}-${organism_id}.fasta.gz" }
+   )
+
+   input:
+   tuple val( id ), val( organism_id )
+   val isoforms
+   val reviewed
+   val extras
+
+   output:
+   tuple val( id ), path( "proteome.fasta.gz" )
+
+   script:
+   def extra_params = extras ? "&${extras}" : ""
+   def isoform_param = isoforms ? "&isoform=2" : "&isoform=0"
+   def reviewed_param = reviewed ? "&reviewed=true" : "&reviewed=false"
+   """
+   set -x
+   EBI_API_URL='https://www.ebi.ac.uk/proteins/api'
+   COMMON_PARAMS='offset=0&size=-1'
+   PROTEIN_PARAMS='${reviewed_param}${isoform_param}${extra_params}'
+
+   curl -X GET --header 'Accept:application/json' \
+      "\$EBI_API_URL"'/proteomes?'"\$COMMON_PARAMS"'&taxid='"${organism_id}" \
+      | jq -r '
+         [ .[] | select(.redundantTo == null) ] as \$nr 
+         
+         | (
+            [ \$nr[] | select(.isReferenceProteome and .isRepresentativeProteome) ] 
+            + [ \$nr[] | select(.isReferenceProteome) ] 
+            + [ \$nr[] | select(.isRepresentativeProteome) ] 
+            + \$nr
+         ) 
+         | first
+         | ( .upid // empty )
+      ' \
+   > proteome-id.txt
+
+   if [ ! -s "proteome-id.txt" ]
+   then
+      echo "Could not find a proteome for taxon ${organism_id}!"
+      echo " - Try ""\$EBI_API_URL"'/proteomes?'"\$COMMON_PARAMS"'&taxid='"${organism_id}"
+      exit 1
+   fi
+
+   curl -X GET --header 'Accept:application/json' \
+      "\$EBI_API_URL"'/genecentric?'"\$COMMON_PARAMS"'&upid='"\$(head -n1 proteome-id.txt)" \
+      | jq -r '.[] | .gene | .accession' \
+   > uniprot-ids.txt
+
+   if [ ! -s "uniprot-ids.txt" ]
+   then
+      echo "Could not find any gene-centric UniProt accessions for taxon ${organism_id}, proteome ID \$(head -n1 proteome-id.txt)!"
+      echo " - Try ""\$EBI_API_URL"'/genecentric?'"\$COMMON_PARAMS"'&upid='"\$(head -n1 proteome-id.txt)"
+      exit 1
+   fi
+
+   split -l 100 uniprot-ids.txt 'chunk_'
+   chunks=(chunk_*)
+
+   for chunk in \${chunks[@]}
+   do
+      ids=\$(tr '\\n' ',' < "\$chunk")
+
+      curl -X GET --header 'Accept:text/x-fasta' \
+         "\$EBI_API_URL"'/proteins?'"\$COMMON_PARAMS""\$PROTEIN_PARAMS"'&taxid='"${organism_id}"'&accession='"\$ids" \
+      >> proteome.fasta
+   done
+   
+   gzip --best proteome.fasta
+
+   """
+}
+
+
 process fetch_fasta_from_uniprot_id {
 
    tag "${uniprot_id}"

--- a/modules/uniprot.nf
+++ b/modules/uniprot.nf
@@ -113,8 +113,8 @@ process fetch_fastas_from_organism_id_v3 {
          .results[]
          | select(.proteomeType == "'"\$1"' proteome")
          | .id
-         | (first // empty)
-      '
+      ' \
+      | head -n1
    )
    QUERIES=("Reference and representative" "Reference" "Representative" "Other")
    PROTEOME_ID=

--- a/modules/uniprot.nf
+++ b/modules/uniprot.nf
@@ -107,47 +107,49 @@ process fetch_fastas_from_organism_id_v3 {
    COMMON_PARAMS='offset=0&size=-1'
    PROTEIN_PARAMS='${reviewed_param}${isoform_param}${extra_params}'
 
-   curl -X GET --header 'Accept:application/json' \
-      "\$EBI_API_URL"'/proteomes?'"\$COMMON_PARAMS"'&is_redundant=false&taxid='"${organism_id}" \
+   function get_proteome_id() (
+      curl -s "https://rest.uniprot.org/proteomes/search?query=(organism_id:${organism_id})&format=json" \
       | jq -r '
-         [ .[] | select(.redundantTo == null) ] as \$nr 
-         
-         | (
-            [ \$nr[] | select(.isReferenceProteome and .isRepresentativeProteome) ] 
-            + [ \$nr[] | select(.isReferenceProteome) ] 
-            + [ \$nr[] | select(.isRepresentativeProteome) ] 
-            + \$nr
-         ) 
-         | first
-         | ( .upid // empty )
-      ' \
-   > proteome-id.txt
+         .results[]
+         | select(.proteomeType == "'"\$1"' proteome")
+         | .id
+      '
+   )
+   QUERIES=("Reference and representative" "Reference" "Representative" "Other")
+   PROTEOME_ID=
+   for q in "\${QUERIES[@]}"
+   do
+      PROTEOME_ID=\$(get_proteome_id "\$q")
+      if [ ! -z \$PROTEOME_ID ]
+      then 
+         break
+      fi
+   done
 
-   if [ ! -s "proteome-id.txt" ]
-   then
-      echo "Could not find a proteome for taxon ${organism_id}!"
-      echo " - Try ""\$EBI_API_URL"'/proteomes?'"\$COMMON_PARAMS"'&taxid='"${organism_id}"
-      exit 1
+   if [ -z \$PROTEOME_ID ]
+   then 
+      echo "Could not find any UniProt proteomes for taxon ${organism_id}!"
+      echo " - Try ""https://rest.uniprot.org/proteomes/search?query=(organism_id:${organism_id})&format=json"
    fi
 
    curl -X GET --header 'Accept:application/json' \
-      "\$EBI_API_URL"'/genecentric?'"\$COMMON_PARAMS"'&upid='"\$(head -n1 proteome-id.txt)" \
+      "\$EBI_API_URL"'/genecentric?'"\$COMMON_PARAMS"'&upid='"\$PROTEOME_ID" \
       | jq -r '.[] | .gene | .accession' \
    > uniprot-ids.txt
 
    if [ ! -s "uniprot-ids.txt" ]
    then
-      echo "Could not find any gene-centric UniProt accessions for taxon ${organism_id}, proteome ID \$(head -n1 proteome-id.txt)!"
+      echo "Could not find any gene-centric UniProt accessions for taxon ${organism_id}, proteome ID \$PROTEOME_ID!"
       echo " - Try ""\$EBI_API_URL"'/genecentric?'"\$COMMON_PARAMS"'&upid='"\$(head -n1 proteome-id.txt)"
       echo "Falling back to UniProt API"
 
-      curl 'https://rest.uniprot.org/uniprotkb/stream?query=(proteome:'"\$(head -n1 proteome-id.txt)"')&format=list&download=true' \
+      curl 'https://rest.uniprot.org/uniprotkb/stream?query=(proteome:'"\$PROTEOME_ID"')&format=list&download=true' \
       > uniprot-ids.txt
 
       if [ ! -s "uniprot-ids.txt" ]
       then
-         echo "Could not find any UniProt accessions for taxon ${organism_id}, proteome ID \$(head -n1 proteome-id.txt)!"
-         echo " - Try "'https://rest.uniprot.org/uniprotkb/stream?query=(proteome:'"\$(head -n1 proteome-id.txt)"')&format=list&download=true'
+         echo "Could not find any UniProt accessions for taxon ${organism_id}, proteome ID \$PROTEOME_ID!"
+         echo " - Try "'https://rest.uniprot.org/uniprotkb/stream?query=(proteome:'"\$PROTEOME_ID"')&format=list&download=true'
          exit 1
       fi
    fi

--- a/modules/uniprot.nf
+++ b/modules/uniprot.nf
@@ -69,38 +69,12 @@ process fetch_fastas_from_organism_id2 {
    """
    set -x
    EBI_API_URL='https://www.ebi.ac.uk/proteins/api/proteins?'
-   COMMON_PARAMS='offset=0&size=-1'
+   COMMON_PARAMS='offset=0&size=-1${reviewed_param}${isoform_param}${extra_params}'
    curl -X GET --header 'Accept:text/x-fasta' \
-      "\$EBI_API_URL""\$COMMON_PARAMS"'&taxid=${organism_id}${reviewed_param}${isoform_param}${extra_params}' \
+      "\$EBI_API_URL""\$COMMON_PARAMS"'&taxid=${organism_id}' \
    | gzip --best \
    > proteome.fasta.gz
    """
-
-   """
-   function get_proteome_id() {
-      curl -s "https://rest.uniprot.org/proteomes/search?query=(taxonomy_id:${organism_id})&format=json" \
-      | jq '.results[] \
-      | select(.proteomeType == "'"\$1"' proteome").id'
-   }
-   QUERIES=("Reference and representative" "Reference" "Representative" "Other")
-   PROTEOME_ID=
-   for q in "\${QUERIES[@]}"
-   do
-      PROTEOME_ID=\$(get_proteome_id "\$q")
-      if [ ! -z \$PROTEOME_ID ]
-      then 
-         break
-      fi
-   done
-
-   wget "https://rest.uniprot.org/uniprotkb/stream?query=(proteome:\$PROTEOME_ID)&format=fasta&download=true&compressed=true" \
-      -O proteome.fasta.gz \
-      || (
-         echo "Failed to download taxonomy ID ${organism_id} with proteome ID \$PROTEOME_ID from UniProt"
-         exit 1   
-      )
-   """
-
 }
 
 

--- a/modules/uniprot.nf
+++ b/modules/uniprot.nf
@@ -80,7 +80,7 @@ process fetch_fastas_from_organism_id_v2 {
 
 process fetch_fastas_from_organism_id_v3 {
 
-   tag "${id}"
+   tag "${id}:${organism_id}"
 
    publishDir( 
       "${params.outputs}/sequences", 

--- a/modules/uniprot.nf
+++ b/modules/uniprot.nf
@@ -143,6 +143,13 @@ process fetch_fastas_from_organism_id_v3 {
 
       curl 'https://rest.uniprot.org/uniprotkb/stream?query=(proteome:'"\$(head -n1 proteome-id.txt)"')&format=list&download=true' \
       > uniprot-ids.txt
+
+      if [ ! -s "uniprot-ids.txt" ]
+      then
+         echo "Could not find any UniProt accessions for taxon ${organism_id}, proteome ID \$(head -n1 proteome-id.txt)!"
+         echo " - Try "'https://rest.uniprot.org/uniprotkb/stream?query=(proteome:'"\$(head -n1 proteome-id.txt)"')&format=list&download=true'
+         exit 1
+      fi
    fi
 
    split -l 100 uniprot-ids.txt 'chunk_'

--- a/nextflow.config
+++ b/nextflow.config
@@ -3,9 +3,9 @@ manifest {
     author          = "Eachan Johnson"
     homePage        = "https://github.com/scbirlab/nf-ggi"
     description     = "Predict gene-gene interactions based on protein-protein interaction predictions and similar metabolites."
-    defaultBranch   = "v0.0.2"
+    defaultBranch   = "v0.0.3"
     nextflowVersion = '!>=24.0.0'
-    version         = "0.0.2"
+    version         = "0.0.3"
     doi             = ''
 
 }
@@ -31,6 +31,7 @@ params {
     format = 'Gene_Name'
     organism_id2 = null  // if interspecies
 
+    // proteome download options
     isoforms = false
     reviewed = false
     proteome_opts = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -71,6 +71,7 @@ conda {
 singularity {
   autoMounts = true
   cacheDir = "${projectDir}/.singularity"
+  pullTimeout = "3h"
 }
 
 docker {

--- a/nextflow.config
+++ b/nextflow.config
@@ -31,6 +31,10 @@ params {
     format = 'Gene_Name'
     organism_id2 = null  // if interspecies
 
+    isoforms = false
+    reviewed = false
+    proteome_opts = false
+
     /* Optional */
     mode = "self"
     test = false
@@ -78,7 +82,8 @@ profiles {
 
   standard {
 
-    conda.enabled = true
+    conda.enabled = false
+    singularity.enabled = true
 
     process {
       executor = 'slurm'

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -26,6 +26,17 @@ script_dir="$(dirname $0)"
 nextflow run "$script_dir"/.. \
     -resume $docker_flag \
     --test \
+    --outputs bait-taxon-test \
+    --organism_id 1773 \
+    --bait 28369 \
+    --bait_is_taxon \
+    --interspecies \
+    --dca --rf2t \
+    --bfd "$bfd" --uniclust "$uniclust"
+    
+nextflow run "$script_dir"/.. \
+    -resume $docker_flag \
+    --test \
     --outputs custom-test \
     --organism_id 559292 \
     --filename "$script_dir"/custom/inputs/sgadata_costanzo2009_rawdata_101120-wheader_10q.txt \
@@ -41,17 +52,6 @@ nextflow run "$script_dir"/.. \
     --outputs bait-test \
     --organism_id 559292 \
     --bait P00931 \
-    --dca --rf2t \
-    --bfd "$bfd" --uniclust "$uniclust"
-
-nextflow run "$script_dir"/.. \
-    -resume $docker_flag \
-    --test \
-    --outputs bait-taxon-test \
-    --organism_id 1773 \
-    --bait 28369 \
-    --bait_is_taxon \
-    --interspecies \
     --dca --rf2t \
     --bfd "$bfd" --uniclust "$uniclust"
 

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -73,5 +73,6 @@ do
         --plots \
         --sample_sheet "$d"inputs/sample-sheet.csv \
         --inputs "$d"inputs \
-        --outputs "$d"outputs
+        --outputs "$d"outputs \
+        --bfd "$bfd" --uniclust "$uniclust"
 done

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -8,14 +8,19 @@ if [ "$GITHUB" == "gh" ]
 then
     export NXF_CONTAINER_ENGINE=docker
     docker_flag='-profile gh -stub'
+    uniclust="uniclust30_2018_08"
+    bfd="bfd_metaclust_clu_complete_id30_c90_final_seq.sorted_opt"
+    echo $uniclust > "$uniclust"_test
+    echo $uniclust > "$uniclust".test
+    echo $bfd > "$bfd"_test
 else
     export SINGULARITY_FAKEROOT=1
     docker_flag=''
+    uniclust="/nemo/lab/johnsone/reference/hhdb/uniclust30/uniclust30_2018_08"
+    bfd="/nemo/lab/johnsone/reference/hhdb/bfd_metaclust/bfd_metaclust_clu_complete_id30_c90_final_seq.sorted_opt"
 fi
 
 script_dir="$(dirname $0)"
-uniclust="/nemo/lab/johnsone/reference/hhdb/uniclust30/uniclust30_2018_08"
-bfd="/nemo/lab/johnsone/reference/hhdb/bfd_metaclust/bfd_metaclust_clu_complete_id30_c90_final_seq.sorted_opt"
 
 # Examples without sample sheet
 nextflow run "$script_dir"/.. \


### PR DESCRIPTION
There was an issue of sometimes excessively large numbers of proteins being pulled for a given proteome, in particular human 9606. This was due to isoforms and a mix of reviewed and unreviewed sequences. This PR switches to the EBI Proteins API to download gene-centric proteomes where possible, and exposes the `--reviewed` and `--proteome_opts` flags to customize the proteome download.