### PR TITLE
Cache RF2t and AF2 weights in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ RUN mkdir -p $HOME/.conda && chown -R 1000:1000 $HOME
 COPY environment.yml /tmp/environment.yml
 RUN micromamba create -n env -f /tmp/environment.yml && \
     micromamba clean --all --yes
-RUN micromamba run --no-capture-output -n env \
-    python -c 'from rf2t_micro.weights import get_model_weights; get_model_weights(); from yunta.weights import get_model_weights; get_model_weights()'
+RUN micromamba activate -n env && \
+    python -c 'from rf2t_micro.weights import get_model_weights; get_model_weights(); from yunta.weights import get_model_weights; get_model_weights()' && \
+    micromamba deactivate
 
 ENV PATH=/opt/conda/envs/env/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ RUN eval "$(micromamba shell hook --shell bash)" && \
     micromamba activate env && \
     python -c 'from rf2t_micro.weights import get_model_weights; get_model_weights()' && \
     python -c 'from yunta.weights import get_model_weights; get_model_weights()' && \
-    python -c 'from yunta.interaction_utils import organism_interactions; organism_interactions()' && \
     micromamba deactivate
 
 ENV PATH=/opt/conda/envs/env/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,9 @@ RUN micromamba create -n env -f /tmp/environment.yml && \
 
 RUN eval "$(micromamba shell hook --shell bash)" && \
     micromamba activate env && \
-    python -c 'from rf2t_micro.weights import get_model_weights; get_model_weights(); from yunta.weights import get_model_weights; get_model_weights()' && \
+    python -c 'from rf2t_micro.weights import get_model_weights; get_model_weights()' && \
+    python -c 'from yunta.weights import get_model_weights; get_model_weights()' && \
+    python -c 'from yunta.interaction_utils import organism_interactions; organism_interactions()' && \
     micromamba deactivate
 
 ENV PATH=/opt/conda/envs/env/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,7 @@ RUN mkdir -p $HOME/.conda && chown -R 1000:1000 $HOME
 COPY environment.yml /tmp/environment.yml
 RUN micromamba create -n env -f /tmp/environment.yml && \
     micromamba clean --all --yes
+RUN conda run --no-capture-output -n nf-ggi \
+    python -c 'from rf2t_micro.weights import get_model_weights; get_model_weights(); from yunta.weights import get_model_weights; get_model_weights()'
 
 ENV PATH=/opt/conda/envs/env/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN mkdir -p $HOME/.conda && chown -R 1000:1000 $HOME
 COPY environment.yml /tmp/environment.yml
 RUN micromamba create -n env -f /tmp/environment.yml && \
     micromamba clean --all --yes
-RUN conda run --no-capture-output -n nf-ggi \
+RUN micromamba run --no-capture-output -n nf-ggi \
     python -c 'from rf2t_micro.weights import get_model_weights; get_model_weights(); from yunta.weights import get_model_weights; get_model_weights()'
 
 ENV PATH=/opt/conda/envs/env/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM mambaorg/micromamba:1.5.6
 
+ENV HOME=/home/micromamba
+ENV MAMBA_ROOT_PREFIX=/opt/conda
+WORKDIR $HOME
+
 USER root
 RUN echo "user:x:1001:1001::/home/user:/bin/bash" >> /etc/passwd && \
     mkdir -p /home/user && chown -R 1001:1001 /home/user

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ USER root
 RUN echo "user:x:1001:1001::/home/user:/bin/bash" >> /etc/passwd && \
     mkdir -p /home/user && chown -R 1001:1001 /home/user
 RUN mkdir -p $HOME/.conda && chown -R 1000:1000 $HOME
+USER 1000
+
 COPY environment.yml /tmp/environment.yml
 RUN micromamba create -n env -f /tmp/environment.yml && \
     micromamba clean --all --yes

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN mkdir -p $HOME/.conda && chown -R 1000:1000 $HOME
 COPY environment.yml /tmp/environment.yml
 RUN micromamba create -n env -f /tmp/environment.yml && \
     micromamba clean --all --yes
-RUN micromamba activate -n env && \
+RUN micromamba activate env && \
     python -c 'from rf2t_micro.weights import get_model_weights; get_model_weights(); from yunta.weights import get_model_weights; get_model_weights()' && \
     micromamba deactivate
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN mkdir -p $HOME/.conda && chown -R 1000:1000 $HOME
 COPY environment.yml /tmp/environment.yml
 RUN micromamba create -n env -f /tmp/environment.yml && \
     micromamba clean --all --yes
-RUN micromamba run --no-capture-output -n nf-ggi \
+RUN micromamba run --no-capture-output -n env \
     python -c 'from rf2t_micro.weights import get_model_weights; get_model_weights(); from yunta.weights import get_model_weights; get_model_weights()'
 
 ENV PATH=/opt/conda/envs/env/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ RUN mkdir -p $HOME/.conda && chown -R 1000:1000 $HOME
 COPY environment.yml /tmp/environment.yml
 RUN micromamba create -n env -f /tmp/environment.yml && \
     micromamba clean --all --yes
-RUN micromamba activate env && \
+RUN eval "$(micromamba shell hook --shell bash)" && \
+    micromamba activate env && \
     python -c 'from rf2t_micro.weights import get_model_weights; get_model_weights(); from yunta.weights import get_model_weights; get_model_weights()' && \
     micromamba deactivate
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,12 @@ USER root
 RUN echo "user:x:1001:1001::/home/user:/bin/bash" >> /etc/passwd && \
     mkdir -p /home/user && chown -R 1001:1001 /home/user
 RUN mkdir -p $HOME/.conda && chown -R 1000:1000 $HOME
-USER 1000
 
+USER 1000
 COPY environment.yml /tmp/environment.yml
 RUN micromamba create -n env -f /tmp/environment.yml && \
     micromamba clean --all --yes
+
 RUN eval "$(micromamba shell hook --shell bash)" && \
     micromamba activate env && \
     python -c 'from rf2t_micro.weights import get_model_weights; get_model_weights(); from yunta.weights import get_model_weights; get_model_weights()' && \

--- a/README.md
+++ b/README.md
@@ -175,10 +175,10 @@ pipeline, use the `-latest` flag.
 nextflow run scbirlab/nf-ggi -latest
 ```
 
-If you want to run a particular tagged version of the pipeline, such as `v0.0.3`, you can do so using
+If you want to run a particular tagged version of the pipeline, such as `v0.0.4`, you can do so using
 
 ```bash 
-nextflow run scbirlab/nf-ggi -r v0.0.3
+nextflow run scbirlab/nf-ggi -r v0.0.4
 ```
 
 For help, use `nextflow run scbirlab/nf-ggi --help`.

--- a/environment.yml
+++ b/environment.yml
@@ -15,5 +15,5 @@ dependencies:
     - conda-forge::wget
     - pip:
         - "pandas"
-        - "yunta[cuda12]>=0.0.3"
+        - "yunta[cuda12]>=0.0.4"
         

--- a/nextflow.config
+++ b/nextflow.config
@@ -3,9 +3,9 @@ manifest {
     author          = "Eachan Johnson"
     homePage        = "https://github.com/scbirlab/nf-ggi"
     description     = "Predict gene-gene interactions based on protein-protein interaction predictions and similar metabolites."
-    defaultBranch   = "v0.0.3"
+    defaultBranch   = "v0.0.4"
     nextflowVersion = '!>=24.0.0'
-    version         = "0.0.3"
+    version         = "0.0.4"
     doi             = ''
 
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -72,6 +72,7 @@ singularity {
   autoMounts = true
   cacheDir = "${projectDir}/.singularity"
   pullTimeout = "3h"
+  runOptions = '--no-home --cleanenv --home /home/micromamba'  // allows Singularity to see pre-downloaded weights
 }
 
 docker {

--- a/nextflow.config
+++ b/nextflow.config
@@ -72,6 +72,7 @@ singularity {
   autoMounts = true
   cacheDir = "${projectDir}/.singularity"
   pullTimeout = "3h"
+  runOptions = '--no-home'
 }
 
 docker {

--- a/nextflow.config
+++ b/nextflow.config
@@ -72,7 +72,6 @@ singularity {
   autoMounts = true
   cacheDir = "${projectDir}/.singularity"
   pullTimeout = "3h"
-  runOptions = '--no-home'
 }
 
 docker {


### PR DESCRIPTION
There were issues with Singularity accessing downloaded model weights from inside the container. Now the weights are pre-downloaded and cached in the container.